### PR TITLE
ロールの新規作成

### DIFF
--- a/backend/src/graphql.rs
+++ b/backend/src/graphql.rs
@@ -86,6 +86,7 @@ impl MutationFields for Mutation {
 
         diesel::insert_into(roles::table)
             .values((
+                roles::client_id.eq(1),
                 roles::name.eq(name),
                 roles::purpose.eq(purpose),
                 roles::domains.eq(domains),

--- a/backend/src/schema.graphql
+++ b/backend/src/schema.graphql
@@ -15,6 +15,14 @@ type Mutation {
     domains: String!
     accountabilities: String!
   ): Role! @juniper(ownership: "owned")
+
+  newRole(
+    name: String!
+    purpose: String!
+    domains: String!
+    accountabilities: String!
+    roleId: ID!
+  ): Role! @juniper(ownership: "owned")
 }
 
 type Client {

--- a/frontend/query.graphql
+++ b/frontend/query.graphql
@@ -33,3 +33,9 @@ mutation updateRole($id: ID!, $name: String!, $purpose: String!, $domains: Strin
     ...roleFields
   }
 }
+
+mutation newRole($name: String!, $purpose: String!, $domains: String!, $accountabilities: String!, $roleId: ID!) {
+  newRole(name: $name, purpose: $purpose, domains: $domains, accountabilities: $accountabilities, roleId: $roleId) {
+    ...roleFields
+  }
+}

--- a/frontend/src/generated/graphql.ts
+++ b/frontend/src/generated/graphql.ts
@@ -31,6 +31,7 @@ export type Query = {
 export type Mutation = {
   __typename?: 'Mutation';
   updateRole: Role;
+  newRole: Role;
 };
 
 export type MutationUpdateRoleArgs = {
@@ -39,6 +40,14 @@ export type MutationUpdateRoleArgs = {
   purpose: Scalars['String'];
   domains: Scalars['String'];
   accountabilities: Scalars['String'];
+};
+
+export type MutationNewRoleArgs = {
+  name: Scalars['String'];
+  purpose: Scalars['String'];
+  domains: Scalars['String'];
+  accountabilities: Scalars['String'];
+  roleId: Scalars['ID'];
 };
 
 export type GetRolesQueryVariables = {};
@@ -81,6 +90,16 @@ export type UpdateRoleMutationVariables = {
 export type UpdateRoleMutation = { __typename?: 'Mutation' } & {
   updateRole: { __typename?: 'Role' } & RoleFieldsFragment;
 };
+
+export type NewRoleMutationVariables = {
+  name: Scalars['String'];
+  purpose: Scalars['String'];
+  domains: Scalars['String'];
+  accountabilities: Scalars['String'];
+  roleId: Scalars['ID'];
+};
+
+export type NewRoleMutation = { __typename?: 'Mutation' } & { newRole: { __typename?: 'Role' } & RoleFieldsFragment };
 
 export const RoleFieldsFragmentDoc = gql`
   fragment roleFields on Role {
@@ -180,3 +199,40 @@ export type UpdateRoleMutationOptions = ApolloReactCommon.BaseMutationOptions<
   UpdateRoleMutation,
   UpdateRoleMutationVariables
 >;
+export const NewRoleDocument = gql`
+  mutation newRole($name: String!, $purpose: String!, $domains: String!, $accountabilities: String!, $roleId: ID!) {
+    newRole(name: $name, purpose: $purpose, domains: $domains, accountabilities: $accountabilities, roleId: $roleId) {
+      ...roleFields
+    }
+  }
+  ${RoleFieldsFragmentDoc}
+`;
+export type NewRoleMutationFn = ApolloReactCommon.MutationFunction<NewRoleMutation, NewRoleMutationVariables>;
+
+/**
+ * __useNewRoleMutation__
+ *
+ * To run a mutation, you first call `useNewRoleMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useNewRoleMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [newRoleMutation, { data, loading, error }] = useNewRoleMutation({
+ *   variables: {
+ *      name: // value for 'name'
+ *      purpose: // value for 'purpose'
+ *      domains: // value for 'domains'
+ *      accountabilities: // value for 'accountabilities'
+ *      roleId: // value for 'roleId'
+ *   },
+ * });
+ */
+export const useNewRoleMutation = (
+  baseOptions?: ApolloReactHooks.MutationHookOptions<NewRoleMutation, NewRoleMutationVariables>,
+) => ApolloReactHooks.useMutation<NewRoleMutation, NewRoleMutationVariables>(NewRoleDocument, baseOptions);
+export type NewRoleMutationHookResult = ReturnType<typeof useNewRoleMutation>;
+export type NewRoleMutationResult = ApolloReactCommon.MutationResult<NewRoleMutation>;
+export type NewRoleMutationOptions = ApolloReactCommon.BaseMutationOptions<NewRoleMutation, NewRoleMutationVariables>;


### PR DESCRIPTION
#2 の対応

# 入力画面に遷移するボタン追加(右上の `new` )
<img width="1332" alt="スクリーンショット 2020-06-01 8 17 32" src="https://user-images.githubusercontent.com/1496543/83365230-be115f00-a3e1-11ea-8f5a-97e31b3ce7b7.png">

# フォームは editのを流用(料理部circleにfocusした状態で `new`  ボタン押す)
<img width="1319" alt="スクリーンショット 2020-06-01 8 18 04" src="https://user-images.githubusercontent.com/1496543/83365258-d1242f00-a3e1-11ea-92a2-30d7f9d676dd.png">

# 登録後

<img width="503" alt="スクリーンショット 2020-06-01 8 25 21" src="https://user-images.githubusercontent.com/1496543/83365273-e7ca8600-a3e1-11ea-84f8-17a8b0501980.png">


- 今わかってる問題点
  - 更新後、dbへのinsertまで正常に終わってるが、 view側に反映されてない
    - これは、useGetRolesQuery をもう一回読んで最新のtreeを取得しなおせば良さそうだがその方向でよい？？
      - また、その場合、 useGetRolesQueryをCircleInfo.tsxから呼ぶのはどうするのが一般的？？

  - Circleに対して新規Roleを作成すると上手く表示されるが、Roleに対して新規Roleを登録すると、DBには登録されるが、UI上何も反映されない(現状Roleは「葉(リーフ)」扱い？)
  - ClinetIDが今1固定で処理している。
    - ClientIDも考慮する場合は、 最初のuseGetRolesQueeryとかログインユーザの概念が必要になる？？

- 質問
  - front側のコード生成コマンドを共有してほしい(今は予想でやってる)
    - front側のコンテナで
      `yarn graphql-codegen --config ./codegen.yml` を叩いている
  - rust側の graphqlの仕組みがあまりわかっていないので教えてほしい。
    - schema.graphql に新しい定義を追加し、特に何もコード生成系のコマンドとかを行っていないのに、language server で schema.graphql に追加したmutationに対応するメソッドが無い、というようなコンパイルエラーを出してくれる。なんで。
